### PR TITLE
Fix version parsing issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,16 +70,19 @@ jobs:
           # Determine version bump based on commit messages or default to patch
           COMMITS=$(git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
 
+          # Clean the version string to remove -dirty suffix for semver parsing
+          CLEAN_VERSION=$(echo "${{ steps.current_version.outputs.current_version }}" | sed 's/-dirty$//' | sed 's/-[0-9]*-g[0-9a-f]*$//')
+
           # Determine version bump type based on commit messages
           if echo "$COMMITS" | grep -qE "(feat|feature)"; then
             # Minor version bump for features
-            NEXT_VERSION=$(npx semver ${{ steps.current_version.outputs.current_version }} -i minor)
+            NEXT_VERSION=$(npx semver $CLEAN_VERSION -i minor)
           elif echo "$COMMITS" | grep -qE "(fix|bugfix)"; then
             # Patch version bump for fixes
-            NEXT_VERSION=$(npx semver ${{ steps.current_version.outputs.current_version }} -i patch)
+            NEXT_VERSION=$(npx semver $CLEAN_VERSION -i patch)
           else
             # Default to patch bump
-            NEXT_VERSION=$(npx semver ${{ steps.current_version.outputs.current_version }} -i patch)
+            NEXT_VERSION=$(npx semver $CLEAN_VERSION -i patch)
           fi
 
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR fixes the version parsing issue in the release workflow that was causing failures when trying to create new versions. The issue was that the semver tool couldn't parse version strings with the '-dirty' suffix.\n\nChanges made:\n- Added logic to clean the version string before passing it to the semver tool\n- Removed the '-dirty' suffix and git hash suffix from the version string for proper parsing