### PR TITLE
Update release-new.yml to match release.yml from commit 7b502a3

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 env:
-  NODE_VERSION: "20.18.1"
+  NODE_VERSION: "20"
 
 jobs:
   release:
@@ -36,17 +36,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Debug - Check versions
-        run: |
-          echo "Node.js version: $(node --version)"
-          echo "npm version: $(npm --version)"
-          echo "Prettier version: $(npx prettier --version)"
-
-      - name: Check formatting
-        run: |
-          echo "Checking formatting with Prettier..."
-          npx prettier@3.6.2 --check .github/workflows/release-new.yml || echo "Format check completed"
-
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -64,10 +53,10 @@ jobs:
         id: version_action
         run: |
           # Check which branch we're merging into
-          if [[ "${GITHUB_BASE_REF}" == "release" ]]; then
+          if [[ "${{ github.base_ref }}" == "release" ]]; then
             echo "action=create_new_version" >> $GITHUB_OUTPUT
             echo "Branch: dev -> release, will create new version"
-          elif [[ "${GITHUB_BASE_REF}" == "main" ]]; then
+          elif [[ "${{ github.base_ref }}" == "main" ]]; then
             echo "action=use_existing_version" >> $GITHUB_OUTPUT
             echo "Branch: release -> main, will use existing version"
           else
@@ -80,35 +69,21 @@ jobs:
         id: new_version
         run: |
           # Determine version bump based on commit messages or default to patch
-          COMMITS=$(git log --oneline ${GITHUB_BASE_SHA}..${GITHUB_HEAD_SHA})
+          COMMITS=$(git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
 
-          # Get the current version and extract base version for semver parsing
-          CURRENT_VERSION="${{ steps.current_version.outputs.current_version }}"
-          echo "Raw version: $CURRENT_VERSION"
-          
-          # Extract a valid semver base from the current version
-          # Try to extract version in format v1.2.3 or 1.2.3
-          BASE_VERSION=$(echo "$CURRENT_VERSION" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/v//')
-          
-          # If we couldn't extract a valid version, default to package.json version or 0.0.0
-          if [ -z "$BASE_VERSION" ]; then
-            # Try to get version from package.json
-            PACKAGE_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")
-            BASE_VERSION="$PACKAGE_VERSION"
-          fi
-          
-          echo "Base version: $BASE_VERSION"
+          # Clean the version string to remove -dirty suffix for semver parsing
+          CLEAN_VERSION=$(echo "${{ steps.current_version.outputs.current_version }}" | sed 's/-dirty$//' | sed 's/-[0-9]*-g[0-9a-f]*$//')
 
           # Determine version bump type based on commit messages
           if echo "$COMMITS" | grep -qE "(feat|feature)"; then
             # Minor version bump for features
-            NEXT_VERSION=$(npx semver $BASE_VERSION -i minor)
+            NEXT_VERSION=$(npx semver $CLEAN_VERSION -i minor)
           elif echo "$COMMITS" | grep -qE "(fix|bugfix)"; then
             # Patch version bump for fixes
-            NEXT_VERSION=$(npx semver $BASE_VERSION -i patch)
+            NEXT_VERSION=$(npx semver $CLEAN_VERSION -i patch)
           else
             # Default to patch bump
-            NEXT_VERSION=$(npx semver $BASE_VERSION -i patch)
+            NEXT_VERSION=$(npx semver $CLEAN_VERSION -i patch)
           fi
 
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR updates the release-new.yml workflow file to match the content of the original release.yml file from commit 7b502a3, which had the correct version parsing logic.\n\nChanges include:\n- Reverting NODE_VERSION back to \"20\" instead of \"20.18.1\"\n- Using the original github.base_ref syntax instead of GITHUB_BASE_REF\n- Using the original commit SHA references instead of GITHUB_BASE_SHA/GITHUB_HEAD_SHA\n- Removing debug/check formatting steps that were added temporarily\n\nThis should resolve any version parsing issues in the release workflow.