### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,4 +1,6 @@
 name: Branch Protection
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/blackjoeyai-cpu/nutrigenius-meal-planner/security/code-scanning/5](https://github.com/blackjoeyai-cpu/nutrigenius-meal-planner/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN. The recommended minimal setting for workflows that do not require repo write permissions is `contents: read`, which allows only reading repository contents and prevents any write access. Since the workflow does not perform any actions that require write permissions, placing this block at the top-level (right after the `name:` and before `on:`) is the single best way to remedy the issue. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
