### PR TITLE
fix(release): properly include changelog and version info in GitHub releases

### DIFF
--- a/.github/workflows/ci-cd-optimized.yml
+++ b/.github/workflows/ci-cd-optimized.yml
@@ -414,6 +414,22 @@ jobs:
         run: |
           npm run changelog
 
+      - name: Read Changelog Content
+        if: steps.version_action.outputs.action == 'create_new_version'
+        id: changelog_content
+        run: |
+          echo 'content<<EOF' >> $GITHUB_OUTPUT
+          cat TEMP_CHANGELOG.md >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: Read Version Content
+        if: steps.version_action.outputs.action == 'create_new_version'
+        id: version_content
+        run: |
+          echo 'content<<EOF' >> $GITHUB_OUTPUT
+          cat src/version.json >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release (dev → release)
         if: steps.version_action.outputs.action == 'create_new_version'
         uses: actions/create-release@v1
@@ -429,11 +445,11 @@ jobs:
 
             ### 📝 Changelog
 
-            $(cat TEMP_CHANGELOG.md)
+            ${{ steps.changelog_content.outputs.content }}
 
             ### 📦 Version Information
             ```json
-            $(cat src/version.json)
+            ${{ steps.version_content.outputs.content }}
             ```
           draft: false
           prerelease: false


### PR DESCRIPTION
Fixed issue where $(cat TEMP_CHANGELOG.md) and $(cat src/version.json) were being treated as literal strings instead of being executed to include the actual file contents in GitHub releases. Updated the CI/CD workflow to properly read and include these files using GitHub Actions output syntax.