### PR TITLE
fix(release): update GitHub Actions permissions for tag creation

### DIFF
--- a/.github/workflows/ci-cd-optimized.yml
+++ b/.github/workflows/ci-cd-optimized.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   security-events: write
   actions: read
@@ -318,12 +318,14 @@ jobs:
       (github.base_ref == 'release' || github.base_ref == 'main')
     runs-on: ubuntu-latest
     needs: [build, validate]
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -338,6 +340,9 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global push.default simple
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Get current version
         id: current_version
@@ -403,11 +408,15 @@ jobs:
         run: |
           git tag -a "v${{ steps.new_version.outputs.next_version }}" -m "Release version ${{ steps.new_version.outputs.next_version }}"
           git push origin "v${{ steps.new_version.outputs.next_version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Push version updates (dev → release)
         if: steps.version_action.outputs.action == 'create_new_version'
         run: |
           git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Generate Changelog
         if: steps.version_action.outputs.action == 'create_new_version'
@@ -434,7 +443,7 @@ jobs:
         if: steps.version_action.outputs.action == 'create_new_version'
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.new_version.outputs.next_version }}
           release_name: Release v${{ steps.new_version.outputs.next_version }}


### PR DESCRIPTION
Fixed issue where GitHub Actions couldn't create and push tags due to insufficient permissions. Updated the workflow to use a custom RELEASE_TOKEN with fallback to GITHUB_TOKEN for tag operations. This ensures that the workflow can successfully create and push tags when merging to release branch.